### PR TITLE
Update `.env.dist` to fix #151 CSRF missconfigurations

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -6,6 +6,7 @@ SECRET_KEY=django-insecure-j8op9)1q8$1&0^s&p*_0%d#pr@w9qj@1o=3#@d=a(^@9@zd@%j
 
 # Don't use "*" for ALLOWED_HOSTS in production
 ALLOWED_HOSTS=www.example.com,example.com,*
+CSRF_TRUSTED_ORIGINS=example.com,*
 
 # Database URL
 


### PR DESCRIPTION
## Fix #151 

- Add CSRF_TRUSTED_ORIGINS env variable example to prevent deployment issues.

It could help to update the official documentation about those mandatory env variables on docker deployments using docker-compose. 

Please correct any missing 