### PR TITLE
[FIX] Complying with RFC5321 regarding MAIL FROM 

### DIFF
--- a/base/views.py
+++ b/base/views.py
@@ -1220,7 +1220,7 @@ def mail_server_test_email(request):
                 msg.attach_alternative(html_content, "text/html")
 
                 # Attach the image
-                image_path = settings.STATIC_ROOT + "/images/ui/horilla-logo.png"
+                image_path = path.join(settings.STATIC_ROOT, "images/ui/horilla-logo.png")
                 with open(image_path, "rb") as img:
                     msg_img = MIMEImage(img.read())
                     msg_img.add_header("Content-ID", "<unique_image_id>")

--- a/base/views.py
+++ b/base/views.py
@@ -8,6 +8,7 @@ import json
 import uuid
 from datetime import datetime, timedelta
 from urllib.parse import parse_qs, unquote, urlencode
+from os import path
 
 from django import forms
 from django.apps import apps
@@ -486,7 +487,7 @@ class HorillaPasswordResetView(PasswordResetView):
             opts = {
                 "use_https": self.request.is_secure(),
                 "token_generator": self.token_generator,
-                "from_email": email_backend.dynamic_username_with_display_name,
+                "from_email": email_backend.dynamic_from_email_with_display_name,
                 "email_template_name": self.email_template_name,
                 "subject_template_name": self.subject_template_name,
                 "request": self.request,
@@ -1212,7 +1213,7 @@ def mail_server_test_email(request):
                 msg = EmailMultiAlternatives(
                     subject,
                     text_content,
-                    email_backend.dynamic_username_with_display_name,
+                    email_backend.dynamic_from_email_with_display_name,
                     [email_to],
                     connection=email_backend,
                 )

--- a/employee/not_in_out_dashboard.py
+++ b/employee/not_in_out_dashboard.py
@@ -127,7 +127,7 @@ def send_mail_to_employee(request):
         (file.name, file.read(), file.content_type) for file in other_attachments
     ]
     email_backend = ConfiguredEmailBackend()
-    host = email_backend.dynamic_username
+    host = email_backend.dynamic_from_email_with_display_name
 
     if employee_id:
         employee_obj = Employee.objects.filter(id=employee_id)

--- a/helpdesk/threading.py
+++ b/helpdesk/threading.py
@@ -62,7 +62,7 @@ class TicketSendThread(Thread):
             email = EmailMessage(
                 subject,
                 html_message,
-                email_backend.dynamic_username_with_display_name,
+                email_backend.dynamic_from_email_with_display_name,
                 [recipient.email],
             )
             email.content_subtype = "html"
@@ -159,7 +159,7 @@ class AddAssigneeThread(Thread):
             email = EmailMessage(
                 subject,
                 html_message,
-                email_backend.dynamic_username_with_display_name,
+                email_backend.dynamic_from_email_with_display_name,
                 [recipient.email],
             )
             email.content_subtype = "html"
@@ -210,7 +210,7 @@ class RemoveAssigneeThread(Thread):
             email = EmailMessage(
                 subject,
                 html_message,
-                email_backend.dynamic_username_with_display_name,
+                email_backend.dynamic_from_email_with_display_name,
                 [recipient.email],
             )
             email.content_subtype = "html"

--- a/horilla_automations/signals.py
+++ b/horilla_automations/signals.py
@@ -348,7 +348,7 @@ def send_mail(request, automation, instance):
     to = tos[:1]
     cc = tos[1:]
     email_backend = ConfiguredEmailBackend()
-    host = email_backend.dynamic_username
+    host = email_backend.dynamic_from_email_with_display_name
     if mail_to_instance and request:
         attachments = []
         try:

--- a/leave/threading.py
+++ b/leave/threading.py
@@ -41,7 +41,7 @@ class LeaveMailSendThread(Thread):
             email = EmailMessage(
                 subject,
                 html_message,
-                email_backend.dynamic_username_with_display_name,
+                email_backend.dynamic_from_email_with_display_name,
                 [recipient.email],
             )
             email.content_subtype = "html"

--- a/onboarding/views.py
+++ b/onboarding/views.py
@@ -704,7 +704,7 @@ def email_send(request):
         email = EmailMessage(
             f"Hello {candidate.name}, Congratulations on your selection!",
             html_message,
-            email_backend.dynamic_username_with_display_name,
+            email_backend.dynamic_from_email_with_display_name,
             [candidate.email],
         )
         email.content_subtype = "html"
@@ -1627,7 +1627,7 @@ def onboarding_send_mail(request, candidate_id):
             res = send_mail(
                 subject,
                 body,
-                email_backend.dynamic_username_with_display_name,
+                email_backend.dynamic_from_email_with_display_name,
                 [candidate_mail],
                 fail_silently=False,
             )

--- a/payroll/threadings/mail.py
+++ b/payroll/threadings/mail.py
@@ -57,7 +57,7 @@ class MailSendThread(Thread):
             email = EmailMessage(
                 f"Hello, {record['instances'][0].get_name()} Your Payslips is Ready!",
                 html_message,
-                email_backend.dynamic_username_with_display_name,
+                email_backend.dynamic_from_email_with_display_name,
                 [employee.get_mail()],
                 # reply_to=["another@example.com"],
                 # headers={"Message-ID": "foo"},

--- a/payroll/views/component_views.py
+++ b/payroll/views/component_views.py
@@ -974,8 +974,8 @@ def send_slip(request):
     payslip_ids = request.GET.getlist("id")
     payslips = Payslip.objects.filter(id__in=payslip_ids)
     if not getattr(
-        email_backend, "dynamic_username_with_display_name", None
-    ) or not len(email_backend.dynamic_username_with_display_name):
+        email_backend, "dynamic_from_email_with_display_name", None
+    ) or not len(email_backend.dynamic_from_email_with_display_name):
         messages.error(request, "Email server is not configured")
         if view:
             return HttpResponse("<script>window.location.reload()</script>")

--- a/recruitment/views.py
+++ b/recruitment/views.py
@@ -1262,7 +1262,7 @@ def send_acknowledgement(request):
         bdy = request.POST.get("body")
         email_backend = ConfiguredEmailBackend()
         res = send_mail(
-            subject, bdy, email_backend.dynamic_username, [send_to], fail_silently=False
+            subject, bdy, email_backend.dynamic_from_email_with_display_name, [send_to], fail_silently=False
         )
         if res == 1:
             return HttpResponse(

--- a/recruitment/views/views.py
+++ b/recruitment/views/views.py
@@ -1924,7 +1924,7 @@ def send_acknowledgement(request):
         (file.name, file.read(), file.content_type) for file in other_attachments
     ]
     email_backend = ConfiguredEmailBackend()
-    host = email_backend.dynamic_username
+    host = email_backend.dynamic_from_email_with_display_name
     if candidate_id:
         candidate_obj = Candidate.objects.filter(id=candidate_id)
     else:


### PR DESCRIPTION
The way mail_from is handled in the current code is non-compliant and non-working in case of server complying with the protocol. For example, you can't use a MS Exchange server with current code.

The "MAIL FROM:" was using either 'dynamic_username' or 'dynamic_username_with_display_name ' (inconsistent behavior, this pr use only the corrected latter). 
In both case the username field of server mail configuration was used. The username field can be any string : not only a mail address.
In lots of scenario you don't use your email address as smtp username.
In case of Exchange Server, it could be "username@domain" (which can be invalid as an email address lacking the .tld) or "domain/username" which is also not a valid email address...

To fix this we MUST use an email address in MAIL FROM, either in the form of "email@domain.tld" or "User Name <email@domain.tld>"

The commit fix this by ensuring a consistent behavior among all code for sending email with the "email from" instead of "username" mail backend configuration.

It also fixes a non-working string concatenation in base/views.py 
image_path = settings.STATIC_ROOT + "/images/ui/horilla-logo.png"
return a TypeError("unsupported operand type(s) for +: 'PosixPath' and 'str'")

fixed with a image_path = path.join(settings.STATIC_ROOT, "images/ui/horilla-logo.png")
