### PR TITLE
[UPDT] Adding 'manage.py collectstatic' in documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,9 @@ dmypy.json
 # media file
 media/
 
+#collected static files
+staticfiles/
+
 #node_modules
 node_modules/
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ Enter the details asked for creating the admin user for the project.
    python manage.py compilemessages
    ```
 
+6. Collect all the static files in the 'settings.STATIC_ROOT' directory (your_project/staticfiles/ by default). In production, you should serve this directory directly by your webserver.
+   ```bash
+   python manage.py collectstatic
+
 7. Running the project
 To run the project locally, execute the following command:
 


### PR DESCRIPTION
There is no information about running python manage.py collectstatic in documentation.
Static files should be served via the STATIC_ROOT directory by the webserver, for performance reason and in deploy situation (/app/static/* won't be served directly when debug is set to false)

Moreover, without the collectstatic, using the constant 'settings.STATIC_ROOT' will throw an invalid path exception.