### PR TITLE
Wrong mail from attribute

### DIFF
--- a/base/views.py
+++ b/base/views.py
@@ -533,7 +533,7 @@ class EmployeePasswordResetView(PasswordResetView):
                 opts = {
                     "use_https": self.request.is_secure(),
                     "token_generator": self.token_generator,
-                    "from_email": email_backend.dynamic_username_with_display_name,
+                    "from_email": email_backend.dynamic_from_email_with_display_name,
                     "email_template_name": self.email_template_name,
                     "subject_template_name": self.subject_template_name,
                     "request": self.request,


### PR DESCRIPTION
The old attribute was used in a recent commit. Replaced by the the correct dynamic_from_email_with_display_name.