### PR TITLE
Fixed email not sending when leave request is created from create card

### DIFF
--- a/leave/views.py
+++ b/leave/views.py
@@ -2014,7 +2014,10 @@ def user_leave_request(request, id):
                                 icon="people-circle",
                                 redirect=f"/leave/request-view?id={leave_request.id}",
                             )
-
+                    mail_thread = LeaveMailSendThread(
+                    request, leave_request, type="request"
+                    )
+                    mail_thread.start()
                     messages.success(request, _("Leave request created successfully.."))
                     with contextlib.suppress(Exception):
                         notify.send(


### PR DESCRIPTION
In the "My Leave request" page, there was a issue where when a leave request was made through one of the cards, it won't send a email. Now when a leave request is made when with one of the cards, an email will be sent.