### PR TITLE
Feature add CDN hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,29 @@ python manage.py migrate
 For more details:
 [Django Oracle Database](https://docs.djangoproject.com/en/4.2/ref/databases/#oracle-notes)
 
+### **CDN Setup**
+
+The environment variable `CDN` is a boolean that is set to `False` by default in the `settings.py`. If set to `False` (default), the static files will be served from the local static directories (`/staticfiles` and `/media`). If set to `True`, the static files will be served from a CDN. 
+
+To use a CDN for static file hosting, following environment variables are required:
+| Environment Variable | Type | Description |
+|----------------------|------|-------------|
+| `CDN` | Boolean | Set to `True` to use CDN for static file hosting. |
+| `ACCESS_KEY_ID` | String | Access key ID for the CDN. |
+| `SECRET_ACCESS_KEY` | String | Secret access key for the CDN. |
+| `STORAGE_BUCKET_NAME` | String | Name of the storage bucket. |
+| `ENDPOINT_URL` | String | Endpoint URL for the CDN. |
+| `CDN_ENDPOINT_URL` | String | Endpoint URL for the CDN. |
+
+Digital Ocean Spaces example:
+```bash
+CDN=True
+ACCESS_KEY_ID=DO00H8DXXXXXXXXXX
+SECRET_ACCESS_KEY=ecixxxxxxxxxxxxxxxxxxxxxxh24I
+STORAGE_BUCKET_NAME=horilla
+ENDPOINT_URL=https://sfo2.digitaloceanspaces.com
+CDN_ENDPOINT_URL=https://horilla.sfo2.cdn.digitaloceanspaces.com
+```
 
 ###  **Features**
 

--- a/horilla/storages.py
+++ b/horilla/storages.py
@@ -1,0 +1,20 @@
+# storages.py
+
+from django.conf import settings
+from storages.backends.s3boto3 import S3Boto3Storage
+
+class CustomS3Boto3Storage(S3Boto3Storage):
+    def _normalize_name(self, name):
+        # Remove leading slashes
+        name = name.lstrip('/')
+        return super()._normalize_name(name)
+
+    def url(self, name, parameters=None, expire=None, http_method=None):
+        # Normalize the name
+        name = self._normalize_name(name)
+
+        # Handle empty names
+        if not name:
+            return settings.STATIC_URL  # Return the base static URL
+
+        return super().url(name, parameters=parameters, expire=expire, http_method=http_method)

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,3 +70,5 @@ XlsxWriter
 gunicorn
 psycopg2-binary
 whitenoise
+django-storages
+boto3


### PR DESCRIPTION
Added option to use a CDN for static file hosting and document hosting. 

Tested using Digital Ocean Spaces. 

- Boolean var added to enable or disable CDN. 
- Employee document views adjusted so it can be opened via url or local path.
- `storages.py` added and removes leading slashes 

Known issue I am not sure how to fix: 
- when deleting an employee document, the frame refresh shows a 404 and the file is removed from the Horilla UI, but not the CDN. 