### PR TITLE
Add PostgreSQL initdb args for scram-sha-256 authentication

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,6 +22,8 @@ services:
       POSTGRES_DB: horilla
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
+      POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256"
+      PGDATA: /var/lib/postgresql/data/pgdata
     ports:
       - 5432:5432
     restart: unless-stopped


### PR DESCRIPTION
# PostgreSQL Authentication Fix

## Summary of Changes

I encountered authentication errors while setting up PostgreSQL in our Docker environment. Below is the error message that I observed while setting up docker.

``FATAL: password authentication failed for user "postgres" db_1 |``

To resolve this, I updated the `docker-compose.yaml` file to include the following environment variable:

``POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256"``

This ensures the database uses SCRAM-SHA-256 for authentication during initialization.

## Impact of the Fix

- Resolves authentication errors during database setup.
- Makes the deployment and startup process seamless and reliable.
- Improves security by leveraging SCRAM-SHA-256, a more robust authentication method.

## Steps Taken

1. Investigated the error message and confirmed the issue was related to the authentication method.
2. Updated the `docker-compose.yaml` file to include the `POSTGRES_INITDB_ARGS` environment variable with the value `--auth-host=scram-sha-256`.
3. Restarted the containers using `docker-compose down` and `docker-compose up` commands.
4. Verified that the database starts up successfully without authentication errors.

## Conclusion

This fix enhances the overall setup process, making it seamless and error-free while improving security through a robust authentication mechanism.