### PR TITLE
Fix prompt to reset password

### DIFF
--- a/templates/forgot_password.html
+++ b/templates/forgot_password.html
@@ -23,12 +23,12 @@
         </div>
           <div class="oh-auth-card">
             <h1 class="oh-onboarding-card__title oh-onboarding-card__title--h2 text-center my-3">{% trans "Forgot Password" %}?</h1>
-            <p class="text-muted text-center">{% trans "Type in your email to reset the password" %}</p>
+            <p class="text-muted text-center">{% trans "Type in your username to reset the password" %}</p>
             <form method='post'  class="oh-form-group">
               {% csrf_token %}
               <div class="oh-input-group">
                 <label class="oh-label" for="email">{% trans "Username" %}</label>
-                <input type="text" name='email' id="email" class="oh-input w-100" placeholder="e.g. jane.doe@acme.com" autofocus required />
+                <input type="text" name='email' id="email" class="oh-input w-100" placeholder="e.g. janedoe" autofocus required />
               </div>
 
               <button


### PR DESCRIPTION
When on the reset password page, it prompts the user to enter email instead of username.