### PR TITLE
[UPDT] not allow employees from answering feedback if it does not sta…

### DIFF
--- a/pms/views.py
+++ b/pms/views.py
@@ -1828,9 +1828,15 @@ def feedback_answer_get(request, id, **kwargs):
         it will redirect to feedaback_answer.html .
     """
 
+    feedback = Feedback.objects.get(id=id)
+
+    # check if the feedback start_date is not started yet
+    if feedback.start_date > datetime.date.today():
+        messages.info(request, _("Feedback not started yet"))
+        return redirect(feedback_list_view)
+
     user = request.user
     employee = Employee.objects.filter(employee_user_id=user).first()
-    feedback = Feedback.objects.get(id=id)
     answer = Answer.objects.filter(feedback_id=feedback, employee_id=employee)
     question_template = feedback.question_template_id
     questions = question_template.question.all()


### PR DESCRIPTION
Business Case:
- As a manager you create a feedback but not allow the employees to answer it once it is created you just want them to see it and answer them once the start_date is reached.