### PR TITLE
Make python_code field optional in FilingStatusForm

### DIFF
--- a/payroll/forms/tax_forms.py
+++ b/payroll/forms/tax_forms.py
@@ -99,6 +99,7 @@ class FilingStatusForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         attrs: dict = self.fields["use_py"].widget.attrs
+        self.fields["python_code"].required = False
         attrs[
             "onchange"
         ] = """


### PR DESCRIPTION
The `python_code` field was previously required, causing form submission failures when left empty. This resulted in an invalid form control error:  

> _"An invalid form control with name='python_code' is not focusable."_  

Additionally, this issue affected modal dialogs using `aria-hidden="true"`, preventing proper focus on form fields.  

### **Fix:**  
Added the following line in the `__init__` method of `FilingStatusForm` to make the field optional:  

```python
self.fields["python_code"].required = False
```  

This allows the form to be submitted without `python_code`, resolving the issue.  

![image](https://github.com/user-attachments/assets/e8b273b5-53b5-4a51-a1fe-24c3ad64267c)
