### PR TITLE
Deduction Duplication issue solution

### DIFF
--- a/payroll/methods/payslip_calc.py
+++ b/payroll/methods/payslip_calc.py
@@ -515,14 +515,14 @@ def calculate_pre_tax_deduction(*_args, **kwargs):
         include_active_employees=True, is_pretax=True, is_tax=False
     ).exclude(exclude_employees=employee)
 
-    deductions = specific_deductions | conditional_deduction | active_employee_deduction
+    deductions = (specific_deductions | conditional_deduction | active_employee_deduction).distinct()
     deductions = (
         deductions.exclude(one_time_date__lt=start_date)
         .exclude(one_time_date__gt=end_date)
         .exclude(update_compensation__isnull=False)
     )
     # Installment deductions
-    installments = deductions.filter(is_installment=True)
+    installments = deductions.filter(is_installment=True).distinct()
 
     pre_tax_deductions = []
     pre_tax_deductions_amt = []
@@ -622,14 +622,14 @@ def calculate_post_tax_deduction(*_args, **kwargs):
     active_employee_deduction = models.Deduction.objects.filter(
         include_active_employees=True, is_pretax=False, is_tax=False
     ).exclude(exclude_employees=employee)
-    deductions = specific_deductions | conditional_deduction | active_employee_deduction
+    deductions = (specific_deductions | conditional_deduction | active_employee_deduction).distinct()
     deductions = (
         deductions.exclude(one_time_date__lt=start_date)
         .exclude(one_time_date__gt=end_date)
         .exclude(update_compensation__isnull=False)
     )
     # Installment deductions
-    installments = deductions.filter(is_installment=True)
+    installments = deductions.filter(is_installment=True).distinct()
 
     post_tax_deductions = []
     post_tax_deductions_amt = []


### PR DESCRIPTION
Deduction Duplication issue solution #541

When calculating payroll deductions, duplicate entries appear in the results for employees with specific deduction assignments.
I'm not sure if this behavior is intended, but I believe each deduction should be applied only once.


Not tested completely.


