### PR TITLE
Max limit was not taken when creating Deduction based on Gross pay and taxable Gross pay.

### DIFF
--- a/payroll/methods/payslip_calc.py
+++ b/payroll/methods/payslip_calc.py
@@ -838,10 +838,12 @@ def calculate_based_on_taxable_gross_pay(*_args, **kwargs):
 
     """
     component = kwargs["component"]
+    day_dict = kwargs["day_dict"]
     taxable_gross_pay = calculate_taxable_gross_pay(**kwargs)
     taxable_gross_pay = taxable_gross_pay["taxable_gross_pay"]
     rate = component.rate
     amount = taxable_gross_pay * rate / 100
+    amount = compute_limit(component, amount,day_dict)
     return amount
 
 
@@ -859,8 +861,6 @@ def calculate_based_on_net_pay(component, net_pay, day_dict):
     """
     rate = float(component.rate)
     amount = net_pay * rate / 100
-    amount = compute_limit(component, amount, day_dict)
-
     amount = compute_limit(component, amount, day_dict)
     return amount
 
@@ -896,9 +896,7 @@ def calculate_based_on_attendance(*_args, **kwargs):
         attendance_validated=True,
     ).count()
     amount = count * component.per_attendance_fixed_amount
-
     amount = compute_limit(component, amount, day_dict)
-
     return amount
 
 

--- a/payroll/methods/payslip_calc.py
+++ b/payroll/methods/payslip_calc.py
@@ -816,6 +816,7 @@ def calculate_based_on_gross_pay(*_args, **kwargs):
     gross_pay = calculate_gross_pay(**kwargs)
     rate = component.rate
     amount = gross_pay["gross_pay"] * rate / 100
+    amount = compute_limit(component, amount)
     return amount
 
 

--- a/payroll/methods/payslip_calc.py
+++ b/payroll/methods/payslip_calc.py
@@ -813,10 +813,11 @@ def calculate_based_on_gross_pay(*_args, **kwargs):
     """
 
     component = kwargs["component"]
+    day_dict = kwargs["day_dict"]
     gross_pay = calculate_gross_pay(**kwargs)
     rate = component.rate
     amount = gross_pay["gross_pay"] * rate / 100
-    amount = compute_limit(component, amount)
+    amount = compute_limit(component, amount,day_dict)
     return amount
 
 


### PR DESCRIPTION
Added the `compute_limit` method to both `calculate_based_on_gross_pay` and `calculate_based_on_taxable_gross_pay`. However, the maximum limit switch was selected but not applied when generating the payslip.