### PR TITLE
Modal Backdrop Stuck on `/payroll/view-payslip/` After Creating Payslip  and going back using back button.

### DIFF
--- a/payroll/views/component_views.py
+++ b/payroll/views/component_views.py
@@ -20,6 +20,7 @@ from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
+from django.views.decorators.cache import never_cache
 from openpyxl import Workbook
 from openpyxl.styles import Alignment, Border, Font, Side
 from openpyxl.utils import get_column_letter
@@ -996,6 +997,7 @@ def view_individual_payslip(request, employee_id, start_date, end_date):
 
 
 @login_required
+@never_cache
 def view_payslip(request):
     """
     This method is used to render the template for viewing a payslip.


### PR DESCRIPTION
 When a new payslip is created, the application redirects to `/payroll/view-payslip/${payslipId}`. However, if the user navigates back, the modal backdrop remains visible because it was not removed on form submission. This happens because the MailThread processing takes an unknown amount of time, preventing immediate redirection.  

Attempting to remove the modal using `onsubmit="$(this).closest('.oh-modal--show').removeClass('oh-modal--show')"` does not fully resolve the issue. Additionally, when navigating back, the browser displays a cached version, preventing the updated list of payslips from appearing.  

**Proposed Solution:**  
Implement the `no_cache` decorator to prevent the browser from serving cached content and ensure that the updated payslip list is always retrieved when navigating back.

Steps to reproduce:
1. Generate a payslip
2. This will take you the new view
3. Go back using back button of the browser.


![image](https://github.com/user-attachments/assets/f18e3517-cb62-4552-b9a6-d120e5d55078)
