### PR TITLE
Automatic include_all fixed for Deduction form and Allowance form

### DIFF
--- a/horilla/horilla_settings.py
+++ b/horilla/horilla_settings.py
@@ -135,10 +135,10 @@ from django.conf import settings
 
 # Default LDAP settings
 DEFAULT_LDAP_CONFIG = {
-    "LDAP_SERVER": "ldap://127.0.0.1:389",
-    "BIND_DN": "cn=admin,dc=horilla,dc=com",
-    "BIND_PASSWORD": "horilla",
-    "BASE_DN": "ou=users,dc=horilla,dc=com",
+    "LDAP_SERVER": settings.env('LDAP_SERVER'),
+    "BIND_DN": settings.env('BIND_DN'),
+    "BIND_PASSWORD": settings.env('BIND_PASSWORD'),
+    "BASE_DN": settings.env('BASE_DN'),
 }
 
 

--- a/payroll/forms/component_forms.py
+++ b/payroll/forms/component_forms.py
@@ -153,6 +153,11 @@ class AllowanceForm(forms.ModelForm):
             cleaned_data["end_range"] = None
 
     def save(self, commit: bool = ...) -> Any:
+        specific_employees = self.data.getlist("specific_employees")
+        include_all = self.data.get("include_active_employees")
+        condition_based = self.data.get("is_condition_based")
+        if not specific_employees and not include_all and not condition_based:
+            self.instance.include_active_employees = True
         super().save(commit)
         other_conditions = self.data.getlist("other_conditions")
         other_fields = self.data.getlist("other_fields")
@@ -315,6 +320,11 @@ class DeductionForm(forms.ModelForm):
         return table_html
 
     def save(self, commit: bool = ...) -> Any:
+        specific_employees = self.data.getlist("specific_employees")
+        include_all = self.data.get("include_active_employees")
+        condition_based = self.data.get("is_condition_based")
+        if not specific_employees and not include_all and not condition_based:
+            self.instance.include_active_employees = True
         super().save(commit)
         other_conditions = self.data.getlist("other_conditions")
         other_fields = self.data.getlist("other_fields")

--- a/payroll/models/models.py
+++ b/payroll/models/models.py
@@ -1042,13 +1042,6 @@ class Allowance(HorillaModel):
 
     def save(self):
         super().save()
-        if (
-            not self.include_active_employees
-            and not self.specific_employees.first()
-            and not self.is_condition_based
-        ):
-            self.include_active_employees = True
-            super().save()
 
 
 class Deduction(HorillaModel):
@@ -1331,13 +1324,6 @@ class Deduction(HorillaModel):
 
     def save(self):
         super().save()
-        if (
-            not self.include_active_employees
-            and not self.specific_employees.first()
-            and not self.is_condition_based
-        ):
-            self.include_active_employees = True
-            super().save()
 
 
 class Payslip(HorillaModel):


### PR DESCRIPTION
Issue #552 fixed
Moved the logic of setting include_active_employees from Deduction Model save method to Deduction Form save method.

Haven't tested completely.

Moved logic here in DeductionForm save method.

```python
  def save(self, commit: bool = ...) -> Any:
        specific_employees = self.data.getlist("specific_employees")
        include_all = self.data.get("include_active_employees")
        condition_based = self.data.get("is_condition_based")
        if not specific_employees and not include_all and not condition_based:
            self.instance.include_active_employees = True
        super().save(commit)
.
.
.
```

From DeductionModel save method.

```python
    def save(self):
        super().save()
```