### PR TITLE
filtering asset_list by cat_id in asset_list view

### DIFF
--- a/asset/views.py
+++ b/asset/views.py
@@ -355,7 +355,7 @@ def asset_list(request, cat_id):
     context = {}
     asset_under = ""
     asset_filtered = AssetFilter(request.GET)
-    asset_list = asset_filtered.qs
+    asset_list = asset_filtered.qs.filter(asset_category_id = cat_id)
 
     paginator = Paginator(asset_list, get_pagination())
     page_number = request.GET.get("page")


### PR DESCRIPTION
### **Fix for Issue #570**  

- **Filtered the asset list by `cat_id` in the `asset_list` view** to ensure only assets from the selected category are displayed.  
- **Messages in `asset_information.html` are still not appearing** as expected. Currently investigating the issue.  
- The messages can be displayed by **commenting out the `<span>` inside the `if` block**, but this alters the layout of `asset_information.html`. Looking for a proper fix.