### PR TITLE
Column automatic hiding issue in payslip table

### DIFF
--- a/payroll/templates/payroll/payslip/payslip_table.html
+++ b/payroll/templates/payroll/payslip/payslip_table.html
@@ -167,7 +167,7 @@
                 <button type='submit' title="{% trans 'Download' %}" class="oh-btn oh-btn--light-bkg w-100"> <ion-icon name="download"></ion-icon></button>
               </form>
               {% if perms.payroll.add_payslip %}
-                <button hx-confirm="{% trans 'Do you want to send the payslip by mail?' %}" hx-get="{% url 'send-slip' %}?id={{payslip.id}}&view=table" hx-target="#payslips-table"
+                <button hx-confirm="{% trans 'Do you want to send the payslip by mail?' %}" hx-get="{% url 'send-slip' %}?id={{payslip.id}}" hx-target="#payslips-table"
                         title="{% trans 'Send via mail' %}" type="button" {% if payslip.sent_to_employee %}class="oh-btn sent-to-employee w-50"{% else %}class="oh-btn oh-btn--light-bkg w-50"{% endif %}>
                   <ion-icon name="mail-outline"></ion-icon>
                 </button>
@@ -282,7 +282,7 @@
     });
   });
   // toggle columns //
-  toggleColumns("payslip-column-tab","payslipCells")
+  toggleColumns("payslip_column_tab","payslipCells")
   localStoragepayslipCells = localStorage.getItem("payslip_column_tab")
   if (!localStoragepayslipCells) {
     $("#payslipCells").find("[type=checkbox]").prop("checked",true)

--- a/payroll/templates/payroll/payslip/payslip_table.html
+++ b/payroll/templates/payroll/payslip/payslip_table.html
@@ -282,7 +282,7 @@
     });
   });
   // toggle columns //
-  toggleColumns("payslip-column-table","payslipCells")
+  toggleColumns("payslip-column-tab","payslipCells")
   localStoragepayslipCells = localStorage.getItem("payslip_column_tab")
   if (!localStoragepayslipCells) {
     $("#payslipCells").find("[type=checkbox]").prop("checked",true)


### PR DESCRIPTION
When generating payslips, there are a few recurring issues that need to be addressed:

1. **Hidden Columns Issue**:  
   Sometimes, columns in the payslip table get hidden when navigating back after generating a payslip. This issue also occurs when the "Send Mail" button in the payslip table is clicked multiple times (2-3 times). This was because there was typo in the class name when toggling columns in payslip_table.html file
```python
 toggleColumns("payslip-column-table","payslipCells") --->  toggleColumns("payslip_column_tab","payslipCells")
```

2. **Backdrop Issue**:  
   After generating a payslip and navigating back to the listing page, a backdrop appears unnecessarily. This issue has been partially addressed in PR #563, where the backdrop was removed by using a `no_cache` decorator instead of removing the class in `hx-post`. However, the listing is not updated when the back button is pressed, which is why the `no_cache` decorator was used as a workaround.  

### **Reference to Column hiding Issue and backdrop PR**  
- **Hidden Columns Issue**: Refer to issue #527 for details.  
- **Backdrop Issue**: Refer to PR #563 for the proposed fix using the `no_cache` decorator.  