### PR TITLE
Fixed the breadcrumbs for asset module

### DIFF
--- a/asset/apps.py
+++ b/asset/apps.py
@@ -4,6 +4,7 @@ Description: Configuration for the 'asset' app.
 """
 
 from django.apps import AppConfig
+from horilla.horilla_settings import APP_URLS
 
 
 class AssetConfig(AppConfig):
@@ -29,4 +30,5 @@ class AssetConfig(AppConfig):
         urlpatterns.append(
             path("asset/", include("asset.urls")),
         )
+        APP_URLS.append("asset.urls")
         super().ready()

--- a/asset/apps.py
+++ b/asset/apps.py
@@ -4,7 +4,6 @@ Description: Configuration for the 'asset' app.
 """
 
 from django.apps import AppConfig
-from horilla.horilla_settings import APP_URLS
 
 
 class AssetConfig(AppConfig):
@@ -22,9 +21,9 @@ class AssetConfig(AppConfig):
 
     def ready(self):
         from django.urls import include, path
-
         from horilla.horilla_settings import APPS
         from horilla.urls import urlpatterns
+        from horilla.horilla_settings import APP_URLS
 
         APPS.append("asset")
         urlpatterns.append(

--- a/horilla_crumbs/context_processors.py
+++ b/horilla_crumbs/context_processors.py
@@ -326,4 +326,5 @@ urlpatterns.append(
 )
 urlpatterns.append(path("payroll/", lambda request: redirect("view-payroll-dashboard")))
 urlpatterns.append(path("pms/", lambda request: redirect("dashboard-view")))
+urlpatterns.append(path("asset/", lambda request: redirect("asset-dashboard")))
 urlpatterns.append(path("project/", lambda request: redirect("project-dashboard-view")))


### PR DESCRIPTION
Fix for issue #579

I added the "asset.urls" in APP_URLS

```python
APP_URLS.append("asset.urls")
```

also in context_processor.py file of  horilla_crumbs, i added the :

```python
urlpatterns.append(path("asset/", lambda request: redirect("asset-dashboard")))
```