### PR TITLE
Loading of Test data fails due to unique primary key constraint in Allowance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,6 @@ whoosh_index/
 
 #VSCode
 .vscode/
+
+#PyCharm
+.idea/

--- a/base/views.py
+++ b/base/views.py
@@ -236,21 +236,22 @@ def load_demo_database(request):
                     "base_data.json",
                     "work_info_data.json",
                 ]
-                optional_apps = {
-                    "attendance": "attendance_data.json",
-                    "leave": "leave_data.json",
-                    "asset": "asset_data.json",
-                    "recruitment": "recruitment_data.json",
-                    "onboarding": "onboarding_data.json",
-                    "offboarding": "offboarding_data.json",
-                    "pms": "pms_data.json",
-                    "payroll": "payroll_data.json",
-                }
+                optional_apps = [
+                    ("attendance", "attendance_data.json"),
+                    ("leave", "leave_data.json"),
+                    ("asset", "asset_data.json"),
+                    ("recruitment", "recruitment_data.json"),
+                    ("onboarding", "onboarding_data.json"),
+                    ("offboarding", "offboarding_data.json"),
+                    ("pms", "pms_data.json"),
+                    ("payroll", "payroll_data.json"),
+                    ("payroll", "payroll_loanaccount_data.json"),
+                ]
 
                 # Add data files for installed apps
                 data_files += [
                     file
-                    for app, file in optional_apps.items()
+                    for app, file in optional_apps
                     if apps.is_installed(app)
                 ]
 

--- a/horilla_backup/migrations/__init__.py
+++ b/horilla_backup/migrations/__init__.py
@@ -4,14 +4,17 @@ import atexit
 def shutdown_function():
     from horilla_backup.models import GoogleDriveBackup, LocalBackup
 
-    if GoogleDriveBackup.objects.exists():
-        google_drive_backup = GoogleDriveBackup.objects.first()
-        google_drive_backup.active = False
-        google_drive_backup.save()
-    if LocalBackup.objects.exists():
-        local_backup = LocalBackup.objects.first()
-        local_backup.active = False
-        local_backup.save()
+    try:
+        if GoogleDriveBackup.objects.exists():
+            google_drive_backup = GoogleDriveBackup.objects.first()
+            google_drive_backup.active = False
+            google_drive_backup.save()
+        if LocalBackup.objects.exists():
+            local_backup = LocalBackup.objects.first()
+            local_backup.active = False
+            local_backup.save()
+    except:
+        pass
 
 
 try:

--- a/load_data/payroll_data.json
+++ b/load_data/payroll_data.json
@@ -1592,32 +1592,5 @@
       "status": "requested",
       "description": "Software license for Sublime Text (1-year subscription for team development)."
     }
-  },
-  {
-    "model": "payroll.loanaccount",
-    "pk": 1,
-    "fields": {
-      "created_at": "2024-12-12T09:45:26.097Z",
-      "created_by": 1,
-      "modified_by": 1,
-      "is_active": true,
-      "type": "loan",
-      "title": "Medical Loan",
-      "employee_id": 18,
-      "loan_amount": 60000.0,
-      "provided_date": "2024-12-01",
-      "allowance_id": 5,
-      "description": "Loan for parents medical case",
-      "is_fixed": true,
-      "rate": 0.0,
-      "installment_amount": 5000.0,
-      "installments": 12,
-      "installment_start_date": "2025-01-01",
-      "apply_on": "end_of_month",
-      "settled": false,
-      "settled_date": null,
-      "asset_id": null,
-      "deduction_ids": [22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33]
-    }
   }
 ]

--- a/load_data/payroll_loanaccount_data.json
+++ b/load_data/payroll_loanaccount_data.json
@@ -1,0 +1,29 @@
+[
+  {
+    "model": "payroll.loanaccount",
+    "pk": 1,
+    "fields": {
+      "created_at": "2024-12-12T09:45:26.097Z",
+      "created_by": 1,
+      "modified_by": 1,
+      "is_active": true,
+      "type": "loan",
+      "title": "Medical Loan",
+      "employee_id": 18,
+      "loan_amount": 60000.0,
+      "provided_date": "2024-12-01",
+      "allowance_id": 5,
+      "description": "Loan for parents medical case",
+      "is_fixed": true,
+      "rate": 0.0,
+      "installment_amount": 5000.0,
+      "installments": 12,
+      "installment_start_date": "2025-01-01",
+      "apply_on": "end_of_month",
+      "settled": false,
+      "settled_date": null,
+      "asset_id": null,
+      "deduction_ids": [1,2,3]
+    }
+  }
+]

--- a/payroll/signals.py
+++ b/payroll/signals.py
@@ -52,10 +52,9 @@ def create_installments(sender, instance, created, **kwargs):
         loan.is_fixed = True
         loan.one_time_date = instance.provided_date
         loan.is_loan = True
-        loan.save()
         loan.include_active_employees = False
-        loan.specific_employees.add(instance.employee_id)
         loan.save()
+        loan.specific_employees.add(instance.employee_id)
         instance.allowance_id = loan
         super(LoanAccount, instance).save()
     else:


### PR DESCRIPTION
- PyCharm IDE directory ignored
- Due to ORM query in `init` module, `manage.py migrate` fails because there are no tables created at the very first step.
--  How to reproduce: just try to run manage.py migrate with a fresh empty database.
- Needed to split the payroll app test data to avoid primary key unique constraint. Due to post_save signal in LoanAccount, another instance of Allowance get created when payroll test data is created.
-- How to reproduce: Try to load test data after running manage.py migrate