### PR TITLE
Fixed the duplicate contract issue

### DIFF
--- a/payroll/signals.py
+++ b/payroll/signals.py
@@ -18,7 +18,8 @@ def employeeworkinformation_pre_save(sender, instance, **_kwargs):
         instance.employee_id if instance.employee_id.is_active == True else None
     )
     if active_employee is not None:
-        contract_exists = active_employee.contract_set.exists()
+        all_contracts = Contract.objects.entire()
+        contract_exists = all_contracts.filter(employee_id_id=active_employee).exists()
         if not contract_exists:
             contract = Contract()
             contract.contract_name = f"{active_employee}'s Contract"


### PR DESCRIPTION
Fix for #624 
-----
Clicking **"Create"** follows this flow:  

```
'employee-create-personal-info' → (redirection) → 'employee-view-update/<int:obj_id>/'
```  

This results in duplicate contracts because:  
1. In `employee_view_update`, the `employee` object is `None` after redirection.  
2. The `work.save()` method runs again, creating a second contract.  

---

### Contract entries are being created from these two code snippets in different functions  

#### First contract creation in `employee_create_update_personal_info`  
```python
def employee_create_update_personal_info(request, obj_id=None):
    """
    Updates employee's personal information.
    """
    employee = Employee.objects.filter(id=obj_id).first()
    form = EmployeeForm(request.POST, instance=employee)

    if form.is_valid():
        form.save()  # First contract entry is created here
```

#### Duplicate contract creation in `employee_view_update`  
```python
if employee is None:
    employee = emp
    work = EmployeeWorkInformation.objects.entire().filter(employee_id=employee).first()

    if company != "all":
        work.company_id = Company.objects.get(id=company)
        work.save()  # This creates a duplicate contract

    employee.save()
```

---

Both of these `save()` calls trigger a pre-save signal, which is responsible for creating the contract in the database. However, the `contract_exists` check was always returning `False`, which caused the signal to create another contract even when one already existed.  

### Fix – Correcting the contract existence check  
Instead of checking for an existing contract like this:  
```python
contract_exists = active_employee.contract_set.exists()
```
It should be checked like this:  
```python
contract_exists = Contract.objects.entire().filter(employee_id_id=active_employee).exists()
```

This ensures that the query properly identifies existing contracts before creating a new one, preventing duplicate entries.  

---

If there is a better way to handle this, I am open to suggestions.