### PR TITLE
 #632: Fix Issue-Retain Existing Attachments When Updating an Announcement

### DIFF
--- a/base/announcement.py
+++ b/base/announcement.py
@@ -178,13 +178,17 @@ def update_announcement(request, anoun_id):
 
     announcement = Announcement.objects.get(id=anoun_id)
     form = AnnouncementForm(instance=announcement)
+    existing_attachments = announcement.attachments.all() 
     instance_ids = request.GET.get("instance_ids")
     if request.method == "POST":
         form = AnnouncementForm(request.POST, request.FILES, instance=announcement)
         if form.is_valid():
             anou, attachment_ids = form.save(commit=False)
             announcement = anou.save()
-            anou.attachments.set(attachment_ids)
+            if attachment_ids:
+                anou.attachments.set(attachment_ids)
+            else:
+                anou.attachments.set(existing_attachments)
             employees = form.cleaned_data["employees"]
             departments = form.cleaned_data["department"]
             job_positions = form.cleaned_data["job_position"]


### PR DESCRIPTION
This PR resolves Issue #632, which caused previously uploaded attachments to be lost when updating an announcement. The fix ensures that if no new attachments are provided during an update, the existing attachments remain unchanged. Previously, whenever an announcement was edited, the attachment field would be cleared unless a new file was uploaded, leading to unintentional data loss.

To address this, the code now retrieves the existing attachments before updating the announcement and ensures they are retained if no new attachments are supplied. 

This improvement enhances user experience by preventing unnecessary file re-uploads and ensuring that attachments persist unless explicitly modified. The fix has been tested by creating announcements with attachments, editing them without changing the attachment (where the original remained intact), and updating with new attachments (where the old was replaced as expected).