### PR TITLE
Fixed Recruitment dashboard throwing error without onboarding_count

### DIFF
--- a/recruitment/views/dashboard.py
+++ b/recruitment/views/dashboard.py
@@ -159,7 +159,7 @@ def dashboard(request):
             "joining": joining,
             "dep_vacancy": dep_vacancy,
             "stage_chart_count": stage_chart_count,
-            "onboarding_count": onboarding_count,
+            "onboarding_count": hired_candidates.filter(start_onboard=True).count(),
             "total_candidates": total_candidates,
             "skill_zone": skill_zone,
         },


### PR DESCRIPTION
🐛 Bug Fix: onboarding_count key error in Recruitment Dashboard

Issue:
The Recruitment dashboard was throwing an error because the onboarding_count key was not properly assigned in the context dictionary, leading to a missing variable in the template.

Fix:
Assigned onboarding_count by counting hired_candidates with start_onboard=True, ensuring the key is always defined and the dashboard renders correctly.

```
"onboarding_count": hired_candidates.filter(start_onboard=True).count()
```
Screenshots:

Before (Error)
![Screenshot from 2025-03-24 21-41-34](https://github.com/user-attachments/assets/2124c9fb-6b14-4f94-ade8-fe7a068e2b99)

After (Working)
![Screenshot from 2025-03-24 21-43-30](https://github.com/user-attachments/assets/23334a87-4eea-4770-8a2c-f0e9e22c1d9d)
