### PR TITLE
Fixed the typo in rotating work type additional data

### DIFF
--- a/base/forms.py
+++ b/base/forms.py
@@ -895,7 +895,7 @@ class RotatingWorkTypeAssignForm(ModelForm):
                 employee.employee_work_info.work_type_id
             )
             rotating_work_type_assign.next_work_type = rotating_work_type.work_type1
-            rotating_work_type_assign.additional_data["next_shift_index"] = 1
+            rotating_work_type_assign.additional_data["next_work_type_index"] = 1
             based_on = self.cleaned_data["based_on"]
             start_date = self.cleaned_data["start_date"]
             if based_on == "weekly":


### PR DESCRIPTION
@horilla-opensource 
There is a typo in this RotatingWorkTypeAssignForm save method.
In additional data , its using 
```python
rotating_work_type_assign.additional_data["next_shift_index"] = 1 # it should be next_work_type_index
```

and in scheduler.py file of base its searching for this
```python
    next_work_type_index = rotating_work_type.additional_data.get(
        "next_work_type_index", 0
    )
```

This is making the first worktype to be 0th  index only instead it should be one as first already given during creation of rotation.

Also i add ionicons dist folder inside ionicons folder in static, but git is not tracking that. Do you know the reason regarding that. Size of ionicons folder in static is 7mb .