### PR TITLE
Fixed installation on Windows 11 Pro using docker CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.10-slim-bullseye
 
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update && apt-get install -y libcairo2-dev gcc
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   server:
     build:
@@ -9,7 +8,7 @@ services:
     restart: unless-stopped
     environment:
       DATABASE_URL: "postgres://postgres:postgres@db:5432/horilla"
-    command: ./entrypoint.sh
+    command: sh ./entrypoint.sh
     volumes:
       - ./horilla:/app/horilla
     depends_on:


### PR DESCRIPTION
- First equals is added in call with M-Shariq-546
- Version isn't needed any longer in docker-compose
- sh was added in front of ./entrypoint.sh to support windows installation (should be checked on linux)
- Please also note that line endings needed in entrypoint.sh were wrong when checked out, I had to switch to LF here:

![image](https://github.com/user-attachments/assets/06cdc59c-b0a4-4d0d-bab1-49b10af1a41f)

That wasn't possible to commit.