### PR TITLE
Improve Docker Security: Limit PostgreSQL Exposure

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    links:
+      - db
     ports:
       - 8000:8000
     restart: unless-stopped
@@ -24,8 +26,8 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256"
       PGDATA: /var/lib/postgresql/data/pgdata
-    ports:
-      - 5432:5432
+    expose:
+      - 5432
     restart: unless-stopped
     volumes:
       - horilla-data:/var/lib/postgresql/data


### PR DESCRIPTION
### Description
This PR improves the security of the docker-compose.yaml setup by limiting external access to the PostgreSQL service and ensuring proper communication between containers.

### Changes
Replaced the ports directive with expose for the db service to prevent the PostgreSQL port from being accessible externally.

Added links between the web and db services to ensure internal connectivity within the Docker network.

### Motivation
The goal of this update is to enhance the security of the development environment by restricting direct access to the database from outside the Docker network, while still allowing internal services to communicate as needed.