### PR TITLE
Remove version from Docker Compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   server:
     build:


### PR DESCRIPTION
Received this warning when starting application via Docker

```shell
WARN[0000] /[redacted]/horilla/docker-compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

Following the warning, I have removed the version attribute.