### PR TITLE
fix: workaround regarding haystack django exception

### DIFF
--- a/horilla/settings.py
+++ b/horilla/settings.py
@@ -43,6 +43,14 @@ DEBUG = env("DEBUG")
 
 ALLOWED_HOSTS = env("ALLOWED_HOSTS")
 
+
+HAYSTACK_CONNECTIONS = {
+    'default': {
+        'ENGINE': 'haystack.backends.whoosh_backend.WhooshEngine',
+        'PATH': os.path.join(BASE_DIR, 'whoosh_index'),
+    },
+}
+
 # Application definition
 
 INSTALLED_APPS = [


### PR DESCRIPTION
This is the workaround added to make the docker instance start. However, as suggested in the issue the django haystack library should be removed if not used.

Closes #720 