### PR TITLE
chore: add docker compose volume for media files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.github
+.gitignore
+*.md
+LICENSE
+docker-compose.yaml

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,7 @@ services:
     command: sh ./entrypoint.sh
     volumes:
       - ./horilla:/app/horilla
+      - ./media:/app/media
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
Even though PostgreSQL data already has a backup, it does not include media files (such as image profiles, CV, icon, etc). Such assets are important, so they need to be backed up