### PR TITLE
[UPDT] Automation: Fix typo in app name for  permissions_required.

### DIFF
--- a/horilla_automations/views/cbvs.py
+++ b/horilla_automations/views/cbvs.py
@@ -25,7 +25,7 @@ from horilla_views.generic.cbv import views
 
 @method_decorator(login_required, name="dispatch")
 @method_decorator(
-    permission_required("horilla_automation.view_mailautomation"), name="dispatch"
+    permission_required("horilla_automations.view_mailautomation"), name="dispatch"
 )
 class AutomationSectionView(views.HorillaSectionView):
     """
@@ -45,7 +45,7 @@ class AutomationSectionView(views.HorillaSectionView):
 
 @method_decorator(login_required, name="dispatch")
 @method_decorator(
-    permission_required("horilla_automation.view_mailautomation"), name="dispatch"
+    permission_required("horilla_automations.view_mailautomation"), name="dispatch"
 )
 class AutomationNavView(views.HorillaNavView):
     """
@@ -55,7 +55,7 @@ class AutomationNavView(views.HorillaNavView):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.actions = []
-        if self.request.user.has_perm("horilla_automation.add_mailautomation"):
+        if self.request.user.has_perm("horilla_automations.add_mailautomation"):
             self.create_attrs = f"""
                 hx-get="{reverse_lazy("create-automation")}"
                 hx-target="#genericModalBody"
@@ -76,7 +76,7 @@ class AutomationNavView(views.HorillaNavView):
                 }
             )
 
-        if self.request.user.has_perm("horilla_automation.add_mailautomation"):
+        if self.request.user.has_perm("horilla_automations.add_mailautomation"):
             self.actions.append(
                 {
                     "action": "Refresh Automations",
@@ -95,7 +95,7 @@ class AutomationNavView(views.HorillaNavView):
 
 @method_decorator(login_required, name="dispatch")
 @method_decorator(
-    permission_required("horilla_automation.change_mailautomation"), name="dispatch"
+    permission_required("horilla_automations.change_mailautomation"), name="dispatch"
 )
 class AutomationFormView(views.HorillaFormView):
     """
@@ -128,7 +128,7 @@ class AutomationFormView(views.HorillaFormView):
 
 @method_decorator(login_required, name="dispatch")
 @method_decorator(
-    permission_required("horilla_automation.view_mailautomation"), name="dispatch"
+    permission_required("horilla_automations.view_mailautomation"), name="dispatch"
 )
 class AutomationListView(views.HorillaListView):
     """
@@ -182,7 +182,7 @@ class AutomationListView(views.HorillaListView):
 
 @method_decorator(login_required, name="dispatch")
 @method_decorator(
-    permission_required("horilla_automation.view_mailautomation"), name="dispatch"
+    permission_required("horilla_automations.view_mailautomation"), name="dispatch"
 )
 class AutomationDetailedView(views.HorillaDetailedView):
     """
@@ -230,7 +230,7 @@ class AutomationDetailedView(views.HorillaDetailedView):
 
 @method_decorator(login_required, name="dispatch")
 @method_decorator(
-    permission_required("horilla_automation.add_mailautomation"), name="dispatch"
+    permission_required("horilla_automations.add_mailautomation"), name="dispatch"
 )
 class LoadAutomationsView(View):
     template_name = "horilla_automations/load_automation.html"

--- a/horilla_automations/views/views.py
+++ b/horilla_automations/views/views.py
@@ -45,7 +45,7 @@ def get_to_field(request):
 
 
 @login_required
-@permission_required("horilla_automation.delete_mailautomation")
+@permission_required("horilla_automations.delete_mailautomation")
 def delete_automation(request, pk):
     """
     Automation delete view
@@ -60,7 +60,7 @@ def delete_automation(request, pk):
 
 
 @login_required
-@permission_required("horilla_automation.add_mailautomation")
+@permission_required("horilla_automations.add_mailautomation")
 def refresh_automations(request):
     """
     Method to  refresh automation signals


### PR DESCRIPTION
The permissions are not allowed for employees which have Horilla Automation permissions allowed via Settings>General Settings>Employee Permissions because of mismatch in app name. This is fix for that.