### PR TITLE
(fix) #744 RegEx in double quotes causes SyntaxWarning, should be raw string in single quotes

### DIFF
--- a/horilla_views/templatetags/generic_template_filters.py
+++ b/horilla_views/templatetags/generic_template_filters.py
@@ -22,7 +22,7 @@ from horilla.horilla_middlewares import _thread_locals
 register = template.Library()
 
 
-numeric_test = re.compile("^\d+$")
+numeric_test = re.compile(r'^\d+$')
 
 date_format_mapping = {
     "DD-MM-YYYY": "%d-%m-%Y",


### PR DESCRIPTION
Just fixed #744 