### PR TITLE
Add Method for Used Leave Percentage of an Employee

### DIFF
--- a/leave/models.py
+++ b/leave/models.py
@@ -472,6 +472,17 @@ class AvailableLeave(HorillaModel):
 
         return leave_taken["total_sum"] if leave_taken["total_sum"] else 0
 
+    def leave_usage_percentage(self):
+        """
+        Returns the percentage of leave used out of the total leave days.
+        """
+        total_days = self.leave_type_id.total_days
+        if total_days == 0:
+            return 0
+        used_days = self.leave_taken()
+        percentage_used = (used_days / total_days) * 100
+        return round(percentage_used, 2)
+    
     # Setting the expiration date for carryforward leaves
     def set_expired_date(self, available_leave, assigned_date):
         period = available_leave.leave_type_id.carryforward_expire_in

--- a/leave/templates/leave/leave_assign/assigned_leave.html
+++ b/leave/templates/leave/leave_assign/assigned_leave.html
@@ -40,7 +40,10 @@
                 <div data-cell-index="4" data-cell-title="{% trans "Carryforward Days" %}" class="oh-sticky-table__th {% if request.sort_option.order == '-carryforward_days' %}arrow-up {% elif request.sort_option.order == 'carryforward_days' %}arrow-down {% else %}arrow-up-down {% endif %}" hx-target='#assignedLeaves' hx-get="{% url 'assign-filter' %}?{{pd}}&sortby=carryforward_days"  >{% trans "Carryforward Days" %}</div>
                 <div data-cell-index="5" data-cell-title="{% trans "Total Leave Days" %}" class="oh-sticky-table__th {% if request.sort_option.order == '-total_leave_days' %}arrow-up {% elif request.sort_option.order == 'total_leave_days' %}arrow-down {% else %}arrow-up-down {% endif %}" hx-target='#assignedLeaves' hx-get="{% url 'assign-filter' %}?{{pd}}&sortby=total_leave_days"  >{% trans "Total Leave Days" %}</div>
                 <div data-cell-index="6" data-cell-title="{% trans "Used Leave Days" %}" class="oh-sticky-table__th" hx-target='#assignedLeaves' hx-get="{% url 'assign-filter' %}?{{pd}}&sortby=total_leave_days"  >{% trans "Used Leave Days" %}</div>
-                <div data-cell-index="7" data-cell-title="{% trans "Assigned Date" %}" class="oh-sticky-table__th {% if request.sort_option.order == '-assigned_date' %}arrow-up {% elif request.sort_option.order == 'assigned_date' %}arrow-down {% else %}arrow-up-down {% endif %}" hx-target='#assignedLeaves' hx-get="{% url 'assign-filter' %}?{{pd}}&sortby=assigned_date"  >{% trans "Assigned Date" %}</div>
+                <div data-cell-index="7" data-cell-title="{% trans "Total Leave Type Days" %}" class="oh-sticky-table__th" hx-target='#assignedLeaves' hx-get="{% url 'assign-filter' %}?{{pd}}&sortby=total_leave_type_days"  >{% trans "Total Leave Type Days" %}</div>
+                <div data-cell-index="8" data-cell-title="{% trans "Assigned Date" %}" class="oh-sticky-table__th {% if request.sort_option.order == '-assigned_date' %}arrow-up {% elif request.sort_option.order == 'assigned_date' %}arrow-down {% else %}arrow-up-down {% endif %}" hx-target='#assignedLeaves' hx-get="{% url 'assign-filter' %}?{{pd}}&sortby=assigned_date"  >{% trans "Assigned Date" %}</div>
+                <div data-cell-index="9" data-cell-title="{% trans "Leave Percentage Used" %}" class="oh-sticky-table__th" hx-target='#assignedLeaves' hx-get="{% url 'assign-filter' %}?{{pd}}&sortby=leave_used_percentage"  >{% trans "Leave Percentage Used" %}</div>
+
                 {% if perms.leave.change_availableleave or perms.leave.delete_availableleave or request.user|is_reportingmanager %}
                     <div class="oh-sticky-table__th">{% trans "Actions" %}</div>
                 {% endif %}
@@ -72,7 +75,9 @@
             <div data-cell-index="4" class="oh-sticky-table__td">{{available_leave.carryforward_days}}</div>
             <div data-cell-index="5" class="oh-sticky-table__td">{% if available_leave.leave_type_id.limit_leave %} {{available_leave.total_leave_days}}{% else %}{% trans "No Limit" %}{% endif %}</div>
             <div data-cell-index="6" class="oh-sticky-table__td">{{available_leave.leave_taken}}</div>
-            <div data-cell-index="7" class="oh-sticky-table__td dateformat_changer">{{available_leave.assigned_date}}</div>
+            <div data-cell-index="7" class="oh-sticky-table__td">{{available_leave.leave_type_id.total_days}}</div>
+            <div data-cell-index="8" class="oh-sticky-table__td dateformat_changer">{{available_leave.assigned_date}}</div>
+            <div data-cell-index="9" class="oh-sticky-table__td">{{available_leave.leave_usage_percentage}} % </div>
             {% if perms.leave.change_availableleave or perms.leave.delete_availableleave or request.user|is_reportingmanager %}
             <div class="oh-sticky-table__td">
                 <div class="oh-btn-group" onclick="event.stopPropagation();">

--- a/leave/templates/leave/leave_assign/group_by.html
+++ b/leave/templates/leave/leave_assign/group_by.html
@@ -70,8 +70,14 @@
                   <div class="oh-sticky-table__th">
                     {% trans "Used Leave Days" %}
                   </div>
+                    <div class="oh-sticky-table__th">
+                    {% trans "Total Leave Type Days" %}
+                  </div>
                   <div class="oh-sticky-table__th">
                     {% trans "Assigned Date" %}
+                  </div>
+                   <div class="oh-sticky-table__th">
+                    {% trans "Leave Percentage Used" %}
                   </div>
                   {% if perms.leave.change_availableleave or perms.leave.delete_availableleave or request.user|is_reportingmanager %}
                     <div class="oh-sticky-table__th">{% trans "Actions" %}</div>
@@ -136,8 +142,14 @@
                   <div class="oh-sticky-table__td">
                     {{available_leave.leave_taken}}
                   </div>
+                  <div class="oh-sticky-table__td">
+                    {{available_leave.leave_type_id.total_days}}
+                  </div>
                   <div class="oh-sticky-table__td dateformat_changer">
                     {{available_leave.assigned_date}}
+                  </div>
+                   <div class="oh-sticky-table__td">
+                    {{available_leave.leave_usage_percentage}} %
                   </div>
                   {% if perms.leave.change_availableleave or perms.leave.delete_availableleave or request.user|is_reportingmanager%}
                   <div class="oh-sticky-table__td">


### PR DESCRIPTION
This PR introduces the leave_usage_percentage method, which returns the percentage of used leaves for a given employee and the respective leave type. This functionality provides a simple way to retrieve leave entitlement availability and monitor leave consumption for a specific employee and the associated leave type. This metric is displayed in the assigned_leave.html and group_by,html leave assign templates.