### PR TITLE
bugfix on condition when creating action from settings

### DIFF
--- a/base/views.py
+++ b/base/views.py
@@ -6555,7 +6555,7 @@ def action_type_create(request):
             form.save()
             form = ActiontypeForm()
             messages.success(request, _("Action has been created successfully!"))
-            if dynamic != "None":
+            if dynamic != None:
                 url = reverse("create-actions")
                 instance = Actiontype.objects.all().order_by("-id").first()
                 mutable_get = request.GET.copy()


### PR DESCRIPTION
I found that when creating action types from configuration, the form shows DisciplinaryActionForm after creation and it doesn't refresh the Action Types list. 
I changed the condition in the view so that it compares with None value instead of "None" string