### PR TITLE
[UPDT] Using docker multi-stage builds to reduce docker image's size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM python:3.10-slim-bullseye AS runtime
 
 ENV PYTHONUNBUFFERED=1
 
-WORKDIR /app
+WORKDIR /app/
 
 COPY --from=builder /install /usr/local
 


### PR DESCRIPTION
Using multi-stage builds to reduce docker image size from 1.19GB to 725MB