### PR TITLE
[FIX] Update pmsChart.js

### DIFF
--- a/pms/static/src/dashboard/pmsChart.js
+++ b/pms/static/src/dashboard/pmsChart.js
@@ -23,6 +23,7 @@ if (objectiveChart != null) {
 			responsive: true,
 			maintainAspectRatio:false,
 			onClick: (e, activeEls) => {
+				if (!activeEls || activeEls.length === 0) return;
 				let datasetIndex = activeEls[0].datasetIndex;
 				let dataIndex = activeEls[0].index;
 				let datasetLabel = e.chart.data.datasets[datasetIndex].label;
@@ -47,14 +48,18 @@ if (objectiveChart != null) {
 			},
 		},
 		plugins: [{
-			afterRender: (chart)=>emptyChart(chart)
+			afterRender: (chart) => {
+				if (typeof emptyChart === "function") {
+					emptyChart(chart);
+		        }
+		    }
 		}],
 	});
 }
 
 function objectiveStatusDataUpdate(data) {
-	objectiveStatusData.labels = data.objective_label;
-	objectiveStatusData.datasets[0].data = data.objective_value;
+	objectiveStatusData.labels = Array.isArray(data?.objective_label) ? data.objective_label : [];
+	objectiveStatusData.datasets[0].data = Array.isArray(data?.objective_value) ? data.objective_value : [];
 	objectiveStatusData.message = data.message;
 	if (objectiveStatusChart){
 		objectiveStatusChart.update();
@@ -78,6 +83,7 @@ $.ajax({
 
 // chart change
 $("#objective-status-chart").click(function (e) {
+	if (!objectiveStatusChart) return;
 	var chartType = objectiveStatusChart.config.type;
 	if (chartType === "line") {
 		chartType = "bar";
@@ -122,6 +128,7 @@ if (keyResultStatusChartCtx != null) {
 			responsive: true,
 			maintainAspectRatio:false,
 			onClick: (e, activeEls) => {
+				if (!activeEls || activeEls.length === 0) return;
 				let datasetIndex = activeEls[0].datasetIndex;
 				let dataIndex = activeEls[0].index;
 				let datasetLabel = e.chart.data.datasets[datasetIndex].label;
@@ -146,14 +153,18 @@ if (keyResultStatusChartCtx != null) {
 			},
 		},
 		plugins: [{
-			afterRender: (chart)=>emptyChart(chart)
+			afterRender: (chart) => {
+				if (typeof emptyChart === "function") {
+					emptyChart(chart);
+		        }
+		    }
 		}],
 	});
 }
 
 function keyResultStatusDataUpdate(data) {
-	keyResultStatusData.labels = data.key_result_label;
-	keyResultStatusData.datasets[0].data = data.key_result_value;
+	keyResultStatusData.labels = (data && data.key_result_label) ? data.key_result_label : [];
+	keyResultStatusData.datasets[0].data = (data && data.key_result_value) ? data.key_result_value : [];
 	keyResultStatusData.message = data.message;
 	if(keyResultStatusChart){
 		keyResultStatusChart.update();
@@ -177,6 +188,7 @@ $.ajax({
 
 // chart change
 $("#key-result-status-chart").click(function (e) {
+	if (!keyResultStatusChart) return;
 	var chartType = keyResultStatusChart.config.type;
 	if (chartType === "line") {
 		chartType = "bar";
@@ -220,6 +232,7 @@ if (feedbackStatusChartCtx != null) {
 			responsive: true,
 			maintainAspectRatio:false,
 			onClick: (e, activeEls) => {
+				if (!activeEls || activeEls.length === 0) return;
 				let datasetIndex = activeEls[0].datasetIndex;
 				let dataIndex = activeEls[0].index;
 				let datasetLabel = e.chart.data.datasets[datasetIndex].label;
@@ -230,14 +243,18 @@ if (feedbackStatusChartCtx != null) {
 			},
 		},
 		plugins: [{
-			afterRender: (chart)=>emptyChart(chart)
+			afterRender: (chart) => {
+				if (typeof emptyChart === "function") {
+					emptyChart(chart);
+		        }
+		    }
 		}],
 	});
 }
 
 function feedbackStatusDataUpdate(data) {
-	feedbackStatusData.labels = data.feedback_label;
-	feedbackStatusData.datasets[0].data = data.feedback_value;
+	feedbackStatusData.labels = (data && data.feedback_label) ? data.feedback_label : [];
+	feedbackStatusData.datasets[0].data = (data && data.feedback_value) ? data.feedback_value : [];
 	feedbackStatusData.message = data.message;
 	if (feedbackStatusChart){
 		feedbackStatusChart.update();


### PR DESCRIPTION
Fix Chart.js Error: Cannot read properties of undefined (reading 'length')

## Description

This pull request fixes a Chart.js runtime error on the dashboard:

`Uncaught TypeError: Cannot read properties of undefined (reading 'length')`

The issue occurs when API responses return missing/undefined values for chart inputs (e.g. `objective_label`, `objective_value`, etc.), causing `chart.data.labels` or `chart.data.datasets[0].data` to become `undefined` instead of an array. Chart.js expects arrays and internally reads `.length`, which triggers the error and breaks dashboard rendering.

This update ensures chart `labels` and `data` are always valid arrays by applying safe fallbacks (`[]`) and adds a safe check before calling `emptyChart()`.

No new dependencies are required.

## Ticket Link

- N/A

## Summary of Changes

- [x] Ensure `labels` and `datasets[0].data` are always arrays using safe fallbacks (`Array.isArray(...) ? ... : []`)
- [x] Prevent Chart.js `.length` crash when backend returns empty/missing chart payload keys
- [x] Call `emptyChart(chart)` only if `emptyChart` is defined to avoid additional runtime errors

## Additional implementation details (OPTIONAL)

- [x] Applied defensive checks in `objectiveStatusDataUpdate()`, `keyResultStatusDataUpdate()`, and `feedbackStatusDataUpdate()`
- [x] Kept existing chart behavior unchanged when valid data exists
- [ ] N/A

## Deployment Notes (OPTIONAL)

- [ ] No deployment changes required (frontend-only fix)

## Screenshot

## Before

- Dashboard throws:
  - `Uncaught TypeError: Cannot read properties of undefined (reading 'length')`
- Charts may fail to render or break the page after AJAX refresh.

## After

- No runtime error when API returns missing/empty fields
- Charts render normally (including empty states)