### PR TITLE
[FIX] Update attendanceChart.js

### DIFF
--- a/attendance/static/dashboard/attendanceChart.js
+++ b/attendance/static/dashboard/attendanceChart.js
@@ -399,7 +399,7 @@ function pendingHourChart(year, month) {
           plugins: [
             {
               afterRender: (chart) => {
-                emptyChart(pendingHoursCanvas);
+                emptyChart(chart);
               },
             },
           ],


### PR DESCRIPTION
Fix Attendance Chart Empty State: use chart instance in emptyChart()

## Description

This pull request fixes an issue in `attendance/static/dashboard/attendanceChart.js` where the Chart.js plugin `afterRender` calls `emptyChart()` using a canvas reference (`pendingHoursCanvas`) instead of the actual Chart.js instance (`chart`).

`emptyChart()` is designed to receive a Chart.js chart object (to access `chart.data`, `chart.ctx`, and `chart.canvas`). Passing the canvas element can cause runtime errors or inconsistent behavior during render, resize, or when the dashboard content is updated (e.g., HTMX swaps / AJAX refresh).

This change updates the plugin callback to pass the correct `chart` instance:
- Before: `emptyChart(pendingHoursCanvas);`
- After: `emptyChart(chart);`

No new dependencies are required.

## Ticket Link

- N/A

## Summary of Changes

- [x] Update Chart.js plugin `afterRender` to call `emptyChart(chart)` instead of passing a canvas element
- [x] Improve stability of empty chart rendering on attendance dashboard (render/resize/reload)
- [ ] N/A

## Additional implementation details (OPTIONAL)

- [x] Keeps the same empty-state behavior (image/message) but ensures correct parameter type is used
- [ ] N/A

## Deployment Notes (OPTIONAL)

- [ ] No deployment changes required (frontend-only fix)

## Screenshot

## Before

- Empty chart rendering may fail or throw errors because `emptyChart()` receives a canvas element instead of a Chart.js instance.

## After

- Empty chart rendering works consistently because `emptyChart()` receives the correct Chart.js `chart` instance.
