### PR TITLE
[FIX] Update sidebar.html

### DIFF
--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -403,42 +403,59 @@ function initializeSummernote(candId,searchWords,) {
   });
 
   function emptyChart(chart, args, options) {
-    flag = false;
-    for (let i = 0; i < chart.data.datasets.length; i++) {
-      flag = flag + chart.data.datasets[i].data.some(Boolean);
+    // Guard: chart/canvas from HTMX swap / destroy / rerender
+    const canvas = chart?.canvas;
+    if (!canvas || !canvas.isConnected) return;
+
+    const parent = canvas.parentElement;
+    if (!parent) return;
+
+    const datasets = chart?.data?.datasets;
+    if (!Array.isArray(datasets)) return;
+
+    let hasData = false;
+    for (let i = 0; i < datasets.length; i++) {
+      const arr = datasets[i]?.data;
+      if (Array.isArray(arr) && arr.some(Boolean)) {
+        hasData = true;
+        break;
+      }
     }
-    if (!flag) {
-      const { ctx, canvas } = chart;
-      chart.clear();
-      const parent = canvas.parentElement;
+    if (hasData) return;
 
-      // Set canvas width/height to match
-      canvas.width = parent.clientWidth;
-      canvas.height = parent.clientHeight;
-      // Calculate center position
-      const x = canvas.width / 2;
-      const y = (canvas.height - 70) / 2;
-      var noDataImage = new Image();
-      noDataImage.src = chart.data.emptyImageSrc
-        ? chart.data.emptyImageSrc
-        : "{% static '/images/ui/no_records.svg' %}";
+    const ctx = chart?.ctx;
+    if (!ctx) return;
 
-      message = chart.data.message
-        ? chart.data.message
-        : emptyMessages[languageCode];
+    chart.clear();
 
-      noDataImage.onload = () => {
-        // Draw image first at center
-        ctx.drawImage(noDataImage, x - 35, y, 70, 70);
+    // Set canvas width/height to match parent
+    canvas.width = parent.clientWidth;
+    canvas.height = parent.clientHeight;
 
-        // Draw text below image
-        ctx.textAlign = "center";
-        ctx.textBaseline = "middle";
-        ctx.fillStyle = "hsl(0,0%,45%)";
-        ctx.font = "16px Poppins";
-        ctx.fillText(message, x, y + 70 + 30);
-      };
-    }
+    // Calculate center position
+    const x = canvas.width / 2;
+    const y = (canvas.height - 70) / 2;
+
+    const noDataImage = new Image();
+    noDataImage.src = chart?.data?.emptyImageSrc
+      ? chart.data.emptyImageSrc
+      : "{% static '/images/ui/no_records.svg' %}";
+
+    const message = chart?.data?.message
+      ? chart.data.message
+      : emptyMessages[languageCode];
+
+    noDataImage.onload = () => {
+      // Guard
+      if (!canvas.isConnected) return;
+
+      ctx.drawImage(noDataImage, x - 35, y, 70, 70);
+      ctx.textAlign = "center";
+      ctx.textBaseline = "middle";
+      ctx.fillStyle = "hsl(0,0%,45%)";
+      ctx.font = "16px Poppins";
+      ctx.fillText(message, x, y + 70 + 30);
+    };
   }
 
   function highlightRow(checkbox) {
@@ -509,3 +526,4 @@ function initializeSummernote(candId,searchWords,) {
     }
   }
 </script>
+


### PR DESCRIPTION
Fix emptyChart() crash when canvas is detached (HTMX / re-render safe)

## Description

This pull request fixes a frontend runtime error in `templates/sidebar.html` related to the `emptyChart()` helper used by Chart.js dashboards.

Previously, `emptyChart()` assumed the chart canvas was always present in the DOM and that `chart.data.datasets[i].data` was always defined. In real usage (especially when the page is updated via HTMX swap, chart is destroyed/re-rendered, or DOM is refreshed), the canvas can be detached and `parentElement` can be `null`, causing crashes like:

- `Cannot read properties of null (reading 'parentElement')`
- Potential downstream errors when dataset/data is missing

This update adds defensive guards to ensure `emptyChart()` only runs when:
- The chart canvas exists and is still attached to the DOM
- The parent element exists
- Datasets exist and contain array data

The empty-state behavior (show image + message) remains unchanged when the chart is valid.

No new dependencies are required.

## Ticket Link

- N/A

## Summary of Changes

- [x] Add DOM safety guards in `emptyChart()` to prevent `parentElement` null crashes
- [x] Validate datasets/data as arrays before checking for values
- [x] Add safety check inside `noDataImage.onload` to prevent drawing after DOM swap/detach

## Additional implementation details (OPTIONAL)

- [x] Uses `chart?.canvas`, `canvas.isConnected`, and `Array.isArray(...)` checks before rendering the empty state
- [x] Exits early when chart already has data (no change to normal chart rendering)

## Deployment Notes (OPTIONAL)

- [ ] No deployment changes required (frontend-only fix)

## Screenshot

## Before

- Dashboard occasionally throws:
  - `Uncaught TypeError: Cannot read properties of null (reading 'parentElement')`
  - Empty-state rendering may break after HTMX swaps / re-renders.

## After

- No runtime error when canvas is detached or chart is re-rendered
- Empty-state rendering works consistently when there is no data