### PR TITLE
[FIX] Update view-requests.html

### DIFF
--- a/attendance/templates/requests/attendance/view-requests.html
+++ b/attendance/templates/requests/attendance/view-requests.html
@@ -64,8 +64,35 @@
 </div>
 
 <script>
+    // --- PERBAIKAN: Menambahkan fungsi yang hilang ---
+    function requestedAttendanceTickCheckboxes() {
+        var ids = [];
+        $(".attendance-request-checkbox:checked").each(function () {
+            ids.push($(this).val());
+        });
+        if (ids.length > 0) {
+            $(".bulk-action-btn").removeClass("d-none").show();
+        } else {
+            $(".bulk-action-btn").addClass("d-none").hide();
+        }
+    }
+    // --------------------------------------------------
 
   $(document).ready(function () {
+    
+    // --- PERBAIKAN: Memastikan fungsi dipanggil saat load & change ---
+    requestedAttendanceTickCheckboxes();
+
+    $(document).on("change", ".attendance-request-checkbox", function () {
+        requestedAttendanceTickCheckboxes();
+    });
+
+    $(document).on("change", "#all-attendance-request", function () {
+        var isChecked = $(this).is(":checked");
+        $(".attendance-request-checkbox").prop("checked", isChecked).change();
+    });
+    // ----------------------------------------------------------------
+
     // Function to handle tab switching
     $('.oh-tabs__tab').on('click', function (e) {
         e.preventDefault();
@@ -136,14 +163,20 @@
     //start of select all //
     $(".requested-attendances-select-all").change(function () {
       setTimeout(function() {
-          addingRequestAttendanceIds();
-      }, 500); // Run after 2 seconds
+          if (typeof addingRequestAttendanceIds === "function") {
+             addingRequestAttendanceIds();
+          }
+      }, 500); // Run after 0.5 seconds
     });
     $("#selectAllInstances").click(function () {
-      selectAllReqAttendance();
+      if (typeof selectAllReqAttendance === "function") {
+         selectAllReqAttendance();
+      }
     });
     $("#unselectAllInstances").click(function () {
-      unselectAllReqAttendance();
+      if (typeof unselectAllReqAttendance === "function") {
+         unselectAllReqAttendance();
+      }
     });
   });
 


### PR DESCRIPTION
Description
This PR fixes a JavaScript Uncaught ReferenceError that occurs in the Attendance Request view (request-attendance-view).

The error happened because the function requestedAttendanceTickCheckboxes() was being called before it was defined, or was missing entirely from the view-requests.html template. This prevented the "Bulk Actions" (Approve/Reject buttons) from appearing when selecting checkboxes.

This change defines the missing function and ensures it is called only after the DOM is fully loaded.

Ticket Link
N/A

Summary of Changes
[x] Defined requestedAttendanceTickCheckboxes() function in templates/requests/attendance/view-requests.html.

[x] Wrapped the function execution inside $(document).ready() to ensure the DOM is loaded.

[x] Added event listeners to handle individual and "select all" checkbox changes correctly.

Additional implementation details (OPTIONAL)
[x] Added logic to show/hide .bulk-action-btn based on the number of checked items.

[ ] Refactored the "Select All" logic to use the new function.

Deployment Notes (OPTIONAL)
[ ] No database migrations required.

[ ] No new library dependencies.

Screenshot
Before
Console error: Uncaught ReferenceError: requestedAttendanceTickCheckboxes is not defined Bulk action buttons do not appear when checking boxes.

After
No console errors. Bulk action buttons appear correctly when at least one attendance request is selected.