### PR TITLE
Docker build on windows and compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ COPY --chown=appuser:appuser . .
 
 # Copy entrypoint script
 COPY --chown=appuser:appuser docker/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
 
 # Create necessary directories and set permissions
 RUN mkdir -p staticfiles media \

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,8 +1,6 @@
 services:
   web:
     build: .
-    ports:
-      - "8000:8000"
     volumes:
       - .:/app
       - staticfiles:/app/staticfiles
@@ -26,16 +24,12 @@ services:
       POSTGRES_PASSWORD: horilla_pass
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
 
   redis:
     image: redis:7-alpine
     command: redis-server --appendonly yes --requirepass horilla_pass
     volumes:
       - redis_data:/data
-    ports:
-      - "6379:6379"
 
   nginx:
     image: nginx:alpine
@@ -47,7 +41,6 @@ services:
       - ./docker/nginx.conf:/etc/nginx/nginx.conf:ro
     depends_on:
       - web
-    profiles: ["production"]
 
 volumes:
   staticfiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 services:
   web:
     build: .
-    ports:
-      - "8000:8000"
     volumes:
       - .:/app
       - staticfiles:/app/staticfiles
@@ -26,16 +24,12 @@ services:
       POSTGRES_PASSWORD: horilla_pass
     volumes:
       - postgres_data:/var/lib/postgresql/data
-    ports:
-      - "5432:5432"
 
   redis:
     image: redis:7-alpine
     command: redis-server --appendonly yes --requirepass horilla_pass
     volumes:
       - redis_data:/data
-    ports:
-      - "6379:6379"
 
   nginx:
     image: nginx:alpine


### PR DESCRIPTION
Building the docker container on Windows will give you problems with the entrypoint.sh script. 
This will solve it, replacing possibly wrong line endings


I then duplicated the compose files to allow testing using the reverse proxy and not exposing ports (for security reasons)