### PR TITLE
[FIX] Remove orphaned check-linkedin URL pattern

### DIFF
--- a/recruitment/urls.py
+++ b/recruitment/urls.py
@@ -700,7 +700,6 @@ urlpatterns = [
         linkedin.update_isactive_linkedin,
         name="update-isactive-linkedin-account",
     ),
-    path("check-linkedin", linkedin.check_linkedin, name="check-linkedin"),
     path(
         "val-linkedin/<int:pk>/", linkedin.validate_linkedin_token, name="val-linkedin"
     ),


### PR DESCRIPTION
## Summary

- Commit `fe9447633` removed the `check_linkedin` view function from `recruitment/views/linkedin.py` (which contained hardcoded dummy LinkedIn client secrets), but left the corresponding URL route in `recruitment/urls.py`
- This orphaned URL pattern causes an `ImportError` when Django attempts to resolve the route
- This PR removes the single dangling `path("check-linkedin", ...)` line from `recruitment/urls.py`

Fixes #1075

## Test plan

- [x] Verify `python manage.py check` passes without errors
- [x] Verify the recruitment module loads correctly
- [x] Confirm no other code references `check-linkedin` URL name or `check_linkedin` view