### PR TITLE
fix: recalculate worked hours before bulk and single validation (#1055)

### DIFF
--- a/attendance/views/views.py
+++ b/attendance/views/views.py
@@ -1290,6 +1290,13 @@ def validate_bulk_attendance(request):
                 continue
 
             attendance.attendance_validated = True
+            # Recalculate worked hours from attendance activities before validation
+            # to ensure Hours Account reflects actual worked time.
+            # Fixes: https://github.com/horilla/horilla-hr/issues/1055
+            if not attendance.attendance_worked_hour or attendance.attendance_worked_hour == "00:00":
+                at_work_seconds = attendance.get_at_work_from_activities()
+                if at_work_seconds > 0:
+                    attendance.attendance_worked_hour = format_time(at_work_seconds)
             attendance.save()
             validate_req_count += 1
 
@@ -1336,6 +1343,13 @@ def validate_this_attendance(request, obj_id):
     try:
         attendance = Attendance.objects.get(id=obj_id)
         attendance.attendance_validated = True
+        # Recalculate worked hours from attendance activities before validation
+        # to ensure Hours Account reflects actual worked time.
+        # Fixes: https://github.com/horilla/horilla-hr/issues/1055
+        if not attendance.attendance_worked_hour or attendance.attendance_worked_hour == "00:00":
+            at_work_seconds = attendance.get_at_work_from_activities()
+            if at_work_seconds > 0:
+                attendance.attendance_worked_hour = format_time(at_work_seconds)
         attendance.save()
         urlencode = request.GET.urlencode()
         modified_url = f"/attendance/attendance-view/?{urlencode}"


### PR DESCRIPTION
## Description

Fixes #1055

When validating attendances in bulk (or individually), the `attendance_worked_hour` field was not recalculated from attendance activities. If the attendance record was created via import/sync with a default worked hour of "00:00", the Hours Account would incorrectly display 0.00 after validation.

## Root Cause

`validate_bulk_attendance()` and `validate_this_attendance()` set `attendance_validated = True` and call `save()` directly, without ensuring `attendance_worked_hour` reflects the actual time calculated from attendance activities.

## Fix

Before calling `save()` in both validation paths, recalculate `attendance_worked_hour` from activities when the current value is empty or "00:00":

```python
if not attendance.attendance_worked_hour or attendance.attendance_worked_hour == "00:00":
    at_work_seconds = attendance.get_at_work_from_activities()
    if at_work_seconds > 0:
        attendance.attendance_worked_hour = format_time(at_work_seconds)
```

## Changes

- `attendance/views/views.py`:
  - `validate_bulk_attendance()`: Added worked hour recalculation before `save()`
  - `validate_this_attendance()`: Added the same recalculation before `save()`

## Impact

- No performance impact for records that already have a correct `attendance_worked_hour`
- Ensures Hours Account accuracy for imported/synced attendance records
