### PR TITLE
fix(base): user group not deleted — redirect kwarg mismatch + missing auth. prefix

### DIFF
--- a/base/templates/base/auth/group_view.html
+++ b/base/templates/base/auth/group_view.html
@@ -44,7 +44,7 @@
 										data-label="Permissions"
 										data-count="{{gp.permissions.all|length}}"
 									>
-										{{permission}} {% if perms.change_group %}
+										{{permission}} {% if perms.auth.change_group %}
 										<form
 											action="{% url 'group-permission-remove' permission.id gp.id %}"
 											method="post"
@@ -64,7 +64,7 @@
 								</div>
 								<div class="oh-sticky-table__sd">
 									<div class="d-flex">
-										{% if perms.change_group %}
+										{% if perms.auth.change_group %}
 										<a
 											href="{% url 'user-group-update' gp.id %}"
 											type="button"
@@ -74,7 +74,7 @@
 											<ion-icon name="create-outline"></ion-icon
 										></a>
 										{% endif %}
-										{% if perms.delete_group %}
+										{% if perms.auth.delete_group %}
 										<form action="{% url 'user-group-delete' gp.id %}"
                           onsubmit="return confirm('{% trans "Are you sure you want to delete this group?" %}');"
 											    class="w-50" method='post'>

--- a/base/urls.py
+++ b/base/urls.py
@@ -108,7 +108,7 @@ urlpatterns = [
         "user-group-delete/<int:obj_id>/",
         views.object_delete,
         name="user-group-delete",
-        kwargs={"model": Group, "redirect": "user-group-view"},
+        kwargs={"model": Group, "redirect_path": "/settings/user-group-view/"},
     ),
     path(
         "group-permission-remove/<int:pid>/<int:gid>/",
@@ -206,7 +206,7 @@ urlpatterns = [
         "settings/company-delete/<int:obj_id>/",
         views.object_delete,
         name="company-delete",
-        kwargs={"model": Company, "redirect": "/settings/company-view"},
+        kwargs={"model": Company, "redirect_path": "/settings/company-view/"},
     ),
     path("settings/department-view/", views.department_view, name="department-view"),
     path(
@@ -489,7 +489,7 @@ urlpatterns = [
         name="rotating-shift-delete",
         kwargs={
             "model": RotatingShift,
-            "redirect": "/settings/rotating-shift-view",
+            "redirect_path": "/settings/rotating-shift-view/",
         },
     ),
     path(


### PR DESCRIPTION
## Description
Two bugs prevented user group deletion from working correctly.

Bug 1: object_delete() reads kwargs.get("redirect_path") but three URL patterns 
passed "redirect" as the key. The group was deleted from the database but the 
redirect failed silently — no success message, wrong page.

Bug 2: group_view.html checked perms.delete_group and perms.change_group without 
the auth. app label prefix. This made the trash and edit buttons invisible for all 
users. The sibling template group_lines.html already used the correct perms.auth.* form.

## Ticket Link
https://github.com/horilla/horilla-hr/issues/1104

## Summary of Changes
- [x] Rename "redirect" → "redirect_path" in base/urls.py for user-group-delete, company-delete, and rotating-shift-delete
- [x] Add auth. prefix to perms.change_group and perms.delete_group in group_view.html

## Screenshot
### Before
- Trash icon not visible for any user
- Clicking delete showed no feedback, wrong redirect

### After
<img width="1918" height="1017" alt="Screenshot 2026-06-20 031530" src="https://github.com/user-attachments/assets/150a1c53-8725-4769-b6d8-304dd6411ef9" />
<img width="1918" height="1015" alt="Screenshot 2026-06-20 031509" src="https://github.com/user-attachments/assets/d8b405dc-dfcd-467e-b30a-123b835137ac" />

- Trash icon visible for users with auth.delete_group permission
- Group deleted with redirect to /settings/user-group-view/ and success message