### PR TITLE
[UPDT] DOCS: Prepare repo for the 2.0 default-branch migration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Horilla Community Support
-    url: https://github.com/horilla-opensource/horilla/discussions
+    url: https://github.com/horilla/horilla-hr/discussions
     about: Ask questions or discuss features here
   - name: Documentation
-    url: https://horilla-opensource.github.io/horilla-docs/
+    url: https://docs.horilla.com
     about: Check the official Horilla documentation

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Description
+
+<!-- What does this PR change, and why? -->
+
+## Checklist
+
+- [ ] **This PR targets `dev/v2.0`, not `2.0`.** Starting July 29, 2026, GitHub defaults new PRs to `2.0` (the repo's default branch) — please change the base branch before submitting if it isn't already `dev/v2.0`.
+- [ ] I've followed the coding conventions in [CONTRIBUTING.md](../CONTRIBUTING.md) (Black + isort, Horilla decorators/`HorillaModel` patterns, etc.)
+- [ ] CI (Docker CI + Quality) passes
+- [ ] I've linked any related issues
+
+## Related issues
+
+<!-- e.g. Closes #123 -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ version: 2
 updates:
   - package-ecosystem: pip
     directory: "/"
+    target-branch: dev/v2.0
     schedule:
       interval: weekly
       day: monday
@@ -15,6 +16,7 @@ updates:
 
   - package-ecosystem: github-actions
     directory: "/"
+    target-branch: dev/v2.0
     schedule:
       interval: weekly
       day: monday

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -6,9 +6,9 @@ name: Docker CI
 
 on:
   push:
-    branches: [dev/v2.0]
+    branches: [dev/v2.0, "2.0"]
   pull_request:
-    branches: [dev/v2.0]
+    branches: [dev/v2.0, "2.0"]
 
 env:
   COMPOSE_FILE: docker-compose.yml

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -6,9 +6,9 @@ name: Quality
 
 on:
   push:
-    branches: [dev/v2.0]
+    branches: [dev/v2.0, "2.0"]
   pull_request:
-    branches: [dev/v2.0]
+    branches: [dev/v2.0, "2.0"]
 
 jobs:
   lint-and-check:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 Thank you for considering contributing to Horilla! We welcome your input and appreciate the community effort to make this project even better.
 
+## Branches
+
+- **`dev/v2.0`** — the active integration branch. Always clone this and always open PRs against this — never against `2.0` directly.
+- **`2.0`** — starting July 29, 2026, this is the repository's default branch: a periodic public snapshot, not where development happens. GitHub will default new PRs here, so double-check your PR's base branch before submitting.
+- **`1.0`/`master`** — v1, now deprioritized. See "Contributing to v1" below and [Discussion #1127](https://github.com/horilla/horilla-hr/discussions/1127) for full background.
+
 ## How to Contribute
 
 1. **Fork the Repository**
@@ -47,6 +53,7 @@ Thank you for considering contributing to Horilla! We welcome your input and app
 
 7. **Push and Open a Pull Request**
    - Target branch: **`dev/v2.0`**
+   - Starting July 29, 2026, GitHub will default your PR's base branch to `2.0` (the new default branch) — you must manually change it to `dev/v2.0` before submitting.
    - Provide a clear title/description and link related issues
    - CI should stay green: **Docker CI** + **Quality**
 
@@ -68,6 +75,10 @@ Thank you for considering contributing to Horilla! We welcome your input and app
 
 - Bugs and features: open a public GitHub issue with reproduction steps.
 - **Security vulnerabilities:** do **not** open a public issue — email `info@horilla.com` per [SECURITY.md](SECURITY.md).
+
+### Contributing to v1 (1.0/master)
+
+v1 is now deprioritized: fixes are considered case-by-case at maintainer discretion, with no guaranteed timeline and no new features backported. If you'd like to contribute a v1 fix, please open an issue first to confirm interest before submitting a PR.
 
 ## Community Guidelines
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 [![License: LGPL v2.1](https://img.shields.io/badge/License-LGPL%20v2.1-blue.svg)](https://www.gnu.org/licenses/lgpl-2.1)
 [![Python](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 [![Django](https://img.shields.io/badge/django-5.0+-green.svg)](https://www.djangoproject.com/)
-[![Stars](https://img.shields.io/github/stars/horilla-opensource/horilla)](https://github.com/horilla-opensource/horilla/stargazers)
-[![Forks](https://img.shields.io/github/forks/horilla-opensource/horilla)](https://github.com/horilla-opensource/horilla/network/members)
+[![Stars](https://img.shields.io/github/stars/horilla/horilla-hr)](https://github.com/horilla/horilla-hr/stargazers)
+[![Forks](https://img.shields.io/github/forks/horilla/horilla-hr)](https://github.com/horilla/horilla-hr/network/members)
+
+> [!IMPORTANT]
+> **Horilla v2 becomes the default branch on July 29, 2026.** If you want to run or deploy Horilla, the default `2.0` branch is what you want. If you want to contribute code, branch from and PR into `dev/v2.0` instead — GitHub will default new PRs to `2.0`, so switch the base branch manually. v1 (`1.0`/`master`) is deprioritized, with fixes considered case-by-case rather than on a guaranteed schedule. Full details → [Discussion #1127](https://github.com/horilla/horilla-hr/discussions/1127).
 
 > **A comprehensive, free, and open-source Human Resource Management System (HRMS) designed to streamline HR operations and enhance organizational efficiency.**
 
@@ -24,6 +27,7 @@
 
 ## 📋 Table of Contents
 
+- [Which Branch Do I Want?](#-which-branch-do-i-want)
 - [Quick Start](#-quick-start)
 - [Installation](#-installation)
 - [Deployment](#-deployment)
@@ -32,14 +36,22 @@
 - [Support](#-support)
 - [License](#-license)
 
+## 🌳 Which Branch Do I Want?
+
+- **`2.0`** (becomes the default branch on July 29, 2026) — the latest stable v2 snapshot. This is what a plain `git clone` gives you. Use it to run or deploy Horilla.
+- **`dev/v2.0`** — the active integration branch. If you want to contribute code, branch from and open PRs against this, not `2.0`.
+- **`1.0`/`master`** — v1, now deprioritized (fixes considered case-by-case, no guaranteed schedule). Not deleted, but no longer where active development happens.
+
+See [Discussion #1127](https://github.com/horilla/horilla-hr/discussions/1127) for full background on this transition.
+
 ## ⚡ Quick Start
 
 ### Using Docker (Recommended)
 
 ```bash
 # Clone the repository
-git clone -b dev/v2.0 https://github.com/horilla-opensource/horilla.git
-cd horilla
+git clone -b dev/v2.0 https://github.com/horilla/horilla-hr.git
+cd horilla-hr
 
 # Start with Docker Compose
 docker-compose up -d
@@ -52,8 +64,8 @@ open http://localhost:8000
 
 ```bash
 # Clone and setup
-git clone -b dev/v2.0 https://github.com/horilla-opensource/horilla.git
-cd horilla
+git clone -b dev/v2.0 https://github.com/horilla/horilla-hr.git
+cd horilla-hr
 
 # Create virtual environment
 python3 -m venv venv
@@ -106,11 +118,11 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 
 ```bash
 # Fork and clone your fork
-git clone -b dev/v2.0 https://github.com/YOUR_USERNAME/horilla.git
-cd horilla
+git clone -b dev/v2.0 https://github.com/YOUR_USERNAME/horilla-hr.git
+cd horilla-hr
 
 # Add upstream remote
-git remote add upstream https://github.com/horilla-opensource/horilla.git
+git remote add upstream https://github.com/horilla/horilla-hr.git
 
 # Create feature branch
 git checkout -b feature/your-feature-name
@@ -120,6 +132,8 @@ pip install -r requirements.txt
 
 # Submit pull request
 ```
+
+> **Note:** starting July 29, 2026, `2.0` is this repo's default branch, and GitHub will pre-select it as your PR's base branch. Before submitting, change the base branch to `dev/v2.0` — that's where active development and reviews happen, not `2.0`.
 
 ### Code Standards
 
@@ -154,9 +168,9 @@ Please report security vulnerabilities to **support@horilla.com**. Do not create
 ### Community Support
 
 - 📖 **Documentation**: [docs.horilla.com](https://docs.horilla.com)
-- 💬 **GitHub Discussions**: [GitHub Discussions](https://github.com/horilla-opensource/horilla/discussions)
-- 🐛 **Bug Reports**: [GitHub Issues](https://github.com/horilla-opensource/horilla/issues)
-- ✨ **Feature Requests**: [GitHub Issues](https://github.com/horilla-opensource/horilla/issues)
+- 💬 **GitHub Discussions**: [GitHub Discussions](https://github.com/horilla/horilla-hr/discussions)
+- 🐛 **Bug Reports**: [GitHub Issues](https://github.com/horilla/horilla-hr/issues)
+- ✨ **Feature Requests**: [GitHub Issues](https://github.com/horilla/horilla-hr/issues)
 
 ### Professional Support
 
@@ -173,6 +187,6 @@ This project is licensed under the [LGPL-2.1 License](LICENSE) - see the LICENSE
 
 **Made with ❤️ by the Horilla Team**
 
-[⭐ Star us on GitHub](https://github.com/horilla-opensource/horilla) | [🐛 Report Bug](https://github.com/horilla-opensource/horilla/issues) | [💡 Request Feature](https://github.com/horilla-opensource/horilla/issues)
+[⭐ Star us on GitHub](https://github.com/horilla/horilla-hr) | [🐛 Report Bug](https://github.com/horilla/horilla-hr/issues) | [💡 Request Feature](https://github.com/horilla/horilla-hr/issues)
 
 </div>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,15 @@
 
 Thank you for your interest in contributing to the Horilla open-source project. We take security seriously and value the community's efforts in helping us identify and address security vulnerabilities. This document outlines the security guidelines for reporting and addressing security issues within the Horilla project.
 
+## Supported Versions
+
+| Version | Branch(es) | Security Support |
+|---|---|---|
+| v2 | `2.0` (default), `dev/v2.0` (active dev) | Yes — actively maintained |
+| v1 | `1.0`, `master` | Deprioritized — fixes considered case-by-case at maintainer discretion, no guaranteed patch schedule |
+
+See [Discussion #1127](https://github.com/horilla/horilla-hr/discussions/1127) for background on this policy.
+
 ## Reporting Security Issues
 
 If you discover a security vulnerability in the Horilla project, please follow these steps to report it:

--- a/docker/README.md
+++ b/docker/README.md
@@ -278,6 +278,8 @@ docker compose logs --tail=100 web
 
 ## 6. Production Deployment
 
+> **Branch note:** this guide's Quick Start clones `dev/v2.0` (the active development branch) for a reason — that section is for local development. For a production deployment, check out the stable `2.0` branch instead (the repository's default branch starting July 29, 2026: `git checkout 2.0` after cloning, or `git clone https://github.com/horilla/horilla-hr.git` with no `-b` flag from that date onward). Running production off `dev/v2.0` means running whatever's currently mid-flight in active development.
+
 Production uses a Compose **overlay** so the zero-config `make dev` path stays intact.
 
 ### Step 1: Create a production `.env`


### PR DESCRIPTION
## Summary
Pre-migration prep for tomorrow's (July 29, 2026) default-branch cutover to `2.0`. Fixes everything identified in a full repo audit:

- Repo-wide stale `horilla-opensource/horilla` name (dead redirect) → `horilla/horilla-hr`, including the knock-on `cd` directory and fork-placeholder fixes this required
- New "Which Branch Do I Want?" explanation in README.md and CONTRIBUTING.md (2.0 vs dev/v2.0 vs 1.0/master)
- Migration banner in README.md
- PR-base-branch warning (GitHub will default new PRs to `2.0` once it's default) in README, CONTRIBUTING, and a new PULL_REQUEST_TEMPLATE.md
- SECURITY.md Supported Versions table (previously had none)
- dependabot.yml pinned to `target-branch: dev/v2.0` on both ecosystems
- CI workflow triggers (`docker-ci.yml`, `quality.yml`) updated to include `2.0`
- Dead docs link in `.github/ISSUE_TEMPLATE/config.yml` replaced with the live `docs.horilla.com`
- `docker/README.md` production-deployment note pointing at `2.0` instead of `dev/v2.0`

Full announcement: #1127

## Test plan
- [x] YAML syntax validated for dependabot.yml, docker-ci.yml, quality.yml, ISSUE_TEMPLATE/config.yml
- [x] All stale-URL replacements verified (0 remaining occurrences)
- [x] Markdown renders correctly (manual review of full README.md/CONTRIBUTING.md/SECURITY.md)
- [x] docs.horilla.com and docs.horilla.com/technical/v2.0/ verified live (200) before use; dead .github.io link confirmed 404 before replacing